### PR TITLE
fix(nix): update lsp deps for nixpkgs 26.05, bump own pin to match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .session.vim
 .direnv
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -22,16 +22,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773222311,
-        "narHash": "sha256-BHoB/XpbqoZkVYZCfXJXfkR+GXFqwb/4zbWnOr2cRcU=",
+        "lastModified": 1782847225,
+        "narHash": "sha256-JC9PjqKYG9ve5U8aDOLQipp3+KLANBHUvGdLZlxzdKI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0590cd39f728e129122770c029970378a79d076a",
+        "rev": "95ca1e203c0750115fd4a6f17d5a245dfe6b1edd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "kapi-vim";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";

--- a/lsp/default.nix
+++ b/lsp/default.nix
@@ -18,13 +18,13 @@
 , statix
 , lua54Packages
   # , vim-language-server
-, nodePackages
+, bash-language-server
 , lua-language-server
 , stylua
 , prettierd
 , taplo
 , yaml-language-server
-, python311Packages
+, python3Packages
 , shfmt
 , shellcheck
 , typst
@@ -72,16 +72,13 @@ let
   ];
 
   pyPkgs = builtins.attrValues {
-    inherit (python311Packages)
+    inherit (python3Packages)
       python
       python-lsp-server
       black;
   };
 
-  shPkgs = [ shfmt shellcheck ] ++ builtins.attrValues {
-    inherit (nodePackages)
-      bash-language-server;
-  };
+  shPkgs = [ shfmt shellcheck bash-language-server ];
 
   typstPkgs = [
     typst


### PR DESCRIPTION
## Summary
Found while bumping kapi-sysconf to the nixpkgs 26.05 channel — since kapi-sysconf's flake sets `inputs.kapi-vim.inputs.nixpkgs.follows = "nixpkgs"`, this repo's nixpkgs is force-overridden to whatever kapi-sysconf uses regardless of this repo's own declared pin, so the breakage below hit immediately even before this repo's own pin was touched.

- `python311Packages`: `black`'s transitive deps (`aiohttp` → `proxy-py` → `httpx` → `anyio` → `trustme` → `pyopenssl` → `sphinx-hook`) now throw `sphinx-9.1.0 not supported for interpreter python3.11` under nixpkgs 26.05. Switched `lsp/default.nix` to `python3Packages` (the generic "current default interpreter" alias, currently 3.13) so this doesn't go stale again on the next channel bump.
- `nodePackages` was removed outright upstream ("many packages are now available at the top level"). `bash-language-server` now lives at `pkgs.bash-language-server` directly.
- Bumped this repo's own `flake.nix` `nixpkgs.url` from `nixos-25.11` to `nixos-26.05` to match, and added `result`/`result-*` to `.gitignore`.

## Test plan
- [x] `nix build .#default` succeeds (`result -> /nix/store/...-kapi-vim`)
- [ ] Confirm `nvim` launches and LSP servers (`bashls`, `pylsp`, etc.) attach correctly once merged and consumed through kapi-sysconf

🤖 Generated with [Claude Code](https://claude.com/claude-code)