### PR TITLE
refactor: single source of truth for per-language LSP toggles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,9 @@ jobs:
       - uses: ./.github/actions/install-nix
       - shell: nix develop .#ci -c bash -e {0}
         run: |
-          nixpkgs-fmt --check flake.nix lsp/default.nix
-          deadnix --fail --hidden flake.nix lsp/default.nix
+          files=$(find . -name "*.nix")
+          nixpkgs-fmt --check $files
+          deadnix --fail --hidden -L .
           statix check .
           stylua --check .
           shfmt -d -s -i 2 -ci -fn .

--- a/flake.nix
+++ b/flake.nix
@@ -49,24 +49,28 @@
             ];
           };
 
+          # Single source of truth for every per-language toggle name and its
+          # default (shared with lsp/default.nix). Kept import-only -- no
+          # `pkgs` needed -- so packages.lite (below) can derive "every
+          # language off" from just the attribute names.
+          languages = import ./lsp/languages.nix;
+
           wrapKapiVim =
             { pname, conf }:
-            { enable_markdown ? true
-            , enable_python ? true
-            , enable_shell ? true
-            , enable_typst ? true
-            , enable_c ? true
-            , enable_rust ? true
-            , enable_go ? true
-            , enable_haskell ? false
-            , enable_lean ? false
-            }: pkgs.buildEnv {
+            { enable_config ? languages.config
+            , enable_python ? languages.python
+            , enable_shell ? languages.shell
+            , enable_typst ? languages.typst
+            , enable_c ? languages.c
+            , enable_rust ? languages.rust
+            , enable_go ? languages.go
+            , enable_js ? languages.js
+            , enable_haskell ? languages.haskell
+            , enable_lean ? languages.lean
+            }@toggles: pkgs.buildEnv {
               name = pname;
               paths =
-                pkgs.callPackage ./lsp
-                  {
-                    inherit enable_markdown enable_python enable_shell enable_typst enable_c enable_rust enable_go enable_haskell enable_lean;
-                  } ++
+                pkgs.callPackage ./lsp toggles ++
                 builtins.attrValues {
                   nvim = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped conf;
                   inherit (pkgs)
@@ -74,6 +78,13 @@
                     ripgrep;
                 };
             };
+
+          # Every enable_<language> toggle forced off, derived from the
+          # registry -- adding a language to lsp/languages.nix means
+          # packages.lite automatically excludes it too, no edits here.
+          allLanguagesOff = lib.genAttrs
+            (map (name: "enable_${name}") (builtins.attrNames languages))
+            (_: false);
         in
         {
           _module.args.pkgs = import nixpkgs {
@@ -107,23 +118,16 @@
               (wrapKapiVim { pname = "kapi-vim-bundle"; conf = bundleConf; })
               { };
 
-            # plug-and-play neovim with every default-on language toggle off
-            # (haskell/lean are already off by default) -- just the base
+            # plug-and-play neovim with every language toggle off (derived
+            # from lsp/languages.nix, so this list can never drift from what
+            # lsp/default.nix actually knows how to gate) -- just the base
             # nixd + lua-language-server + editor tooling, fast enough for
             # CI to build and smoke-test on every run. default/bundle (the
             # full, every-language experience) are exercised in a separate,
             # slower workflow.
             lite = pkgs.lib.makeOverridable
               (wrapKapiVim { pname = "kapi-vim-lite"; conf = bundleConf; })
-              {
-                enable_markdown = false;
-                enable_python = false;
-                enable_shell = false;
-                enable_typst = false;
-                enable_c = false;
-                enable_rust = false;
-                enable_go = false;
-              };
+              allLanguagesOff;
           };
 
           devShells.default = pkgs.mkShellNoCC

--- a/lsp/default.nix
+++ b/lsp/default.nix
@@ -1,13 +1,14 @@
-{ enable_markdown ? true
-, enable_python ? true
-, enable_shell ? true
-, enable_typst ? true
-, enable_c ? true
-, enable_rust ? true
-, enable_go ? true
-, enable_js ? true
-, enable_haskell ? false
-, enable_lean ? false
+{ languages ? import ./languages.nix
+, enable_config ? languages.config
+, enable_python ? languages.python
+, enable_shell ? languages.shell
+, enable_typst ? languages.typst
+, enable_c ? languages.c
+, enable_rust ? languages.rust
+, enable_go ? languages.go
+, enable_js ? languages.js
+, enable_haskell ? languages.haskell
+, enable_lean ? languages.lean
 , lib
 , direnv
 , nix-direnv
@@ -64,7 +65,7 @@ let
       luarocks;
   };
 
-  mkPkgs = [
+  configPkgs = [
     prettierd
     taplo
     yaml-language-server
@@ -117,7 +118,7 @@ let
 in
 nixPkgs
 ++ vimPkgs
-++ lib.optionals enable_markdown mkPkgs
+++ lib.optionals enable_config configPkgs
 ++ lib.optionals enable_python pyPkgs
 ++ lib.optionals enable_shell shPkgs
 ++ lib.optionals enable_c cPkgs

--- a/lsp/languages.nix
+++ b/lsp/languages.nix
@@ -1,0 +1,22 @@
+# Single source of truth for every per-language LSP/toolchain toggle this
+# flake exposes. Each attribute name becomes `enable_<name>` on both
+# `wrapKapiVim` (flake.nix) and `lsp/default.nix`'s callPackage signature,
+# and its value is that toggle's default.
+#
+# Intentionally does NOT import <nixpkgs>/pkgs: flake.nix needs just the
+# name list (to derive "every language off" for packages.lite) without
+# evaluating a full package set to get it; lsp/default.nix only needs it
+# for `? default` values in its own signature -- the actual package attrs
+# (prettierd, gopls, etc.) stay declared where they always were.
+{
+  config = true; # generic formatter (prettierd) + TOML/YAML LSPs -- not markdown-specific
+  python = true;
+  shell = true;
+  typst = true;
+  c = true;
+  rust = true;
+  go = true;
+  js = true;
+  haskell = false;
+  lean = false;
+}


### PR DESCRIPTION
## Summary

Per-language LSP toggles (`enable_markdown`/`python`/`shell`/`typst`/`c`/`rust`/`go`/`js`/`haskell`/`lean`) were duplicated by hand across `flake.nix`'s `wrapKapiVim` and `lsp/default.nix`'s own signature, with no single source of truth. This already caused a real, silent bug: `enable_js` was never listed in `flake.nix`'s manual passthrough, so it could never be toggled off by any package -- including `packages.lite`, whose entire point is "everything off," which still silently included `nodejs`.

- Adds `lsp/languages.nix`: one registry of every toggle name and its default, shared by both files.
- `wrapKapiVim` now forwards toggles wholesale to `callPackage` instead of hand-listing them -- the actual fix, since a name can no longer silently go missing from a passthrough list.
- `packages.lite` is now derived from the registry ("every language off"), not a hand-typed list of 7 flags -- new languages are automatically excluded with no edits needed.
- Renames `enable_markdown` -> `enable_config` (**breaking**): the packages it gates (`prettierd`, `taplo`, `yaml-language-server`) aren't markdown-specific.
- CI's `lint` job now auto-discovers `.nix` files instead of a hardcoded list, so new files are linted without remembering to add them.

Verified: `packages.default`'s hash is unaffected, `packages.lite` correctly drops `nodejs`, and `enable_js` is now reachable. Full details in the commit message.

## Follow-up required

`kapi-sysconf`'s `home.nix` passes `enable_markdown` in its override call -- needs updating to `enable_config` next time `kapi-vim` is bumped there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
