### PR TITLE
refactor(nvim): unbundle the blanket LazyVim import

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -22,8 +22,25 @@ end
 
 lazy.setup({
     spec = {
-        -- add LazyVim and import its plugins
-        { "LazyVim/LazyVim", import = "lazyvim.plugins", version = "v15.14.0" },
+        -- LazyVim itself, pinned. `import = "lazyvim.plugins"` used to pull in
+        -- every lazyvim/plugins/*.lua module implicitly in one line; listed
+        -- explicitly below instead so each future removal is a one-line diff,
+        -- not an opaque blanket import. No functional change: this is the
+        -- exact same set of modules `lazyvim.plugins` would have imported
+        -- (verified by diffing the synced lazy-lock.json plugin list before
+        -- and after this change).
+        { "LazyVim/LazyVim", version = "v15.14.0" },
+        { import = "lazyvim.plugins.init" },
+        { import = "lazyvim.plugins.coding" },
+        { import = "lazyvim.plugins.colorscheme" },
+        { import = "lazyvim.plugins.editor" },
+        { import = "lazyvim.plugins.formatting" },
+        { import = "lazyvim.plugins.linting" },
+        { import = "lazyvim.plugins.lsp" },
+        { import = "lazyvim.plugins.treesitter" },
+        { import = "lazyvim.plugins.ui" },
+        { import = "lazyvim.plugins.util" },
+        { import = "lazyvim.plugins.xtras" },
         { import = "lazyvim.plugins.extras.editor.telescope" },
         { import = "lazyvim.plugins.extras.coding.nvim-cmp" },
         { import = "lazyvim.plugins.extras.coding.luasnip" },


### PR DESCRIPTION
## Summary

Task 3.1 of the gradual LazyVim removal plan: `lua/config/lazy.lua`'s single `{ "LazyVim/LazyVim", import = "lazyvim.plugins" }` implicitly imported every module under LazyVim's own `lua/lazyvim/plugins/` directory (`init`, `coding`, `colorscheme`, `editor`, `formatting`, `linting`, `lsp`, `treesitter`, `ui`, `util`, `xtras` -- confirmed by listing that directory at the pinned `v15.14.0` tag). Replaced it with each of those imports listed explicitly, plus a separate `{ "LazyVim/LazyVim", version = "..." }` entry for the version pin, so future removal of any one category is a one-line diff instead of an opaque blanket import.

No functional change -- this PR only restructures the import, it doesn't remove anything yet.

`xtras.lua` needed special attention: it's not a static plugin list, it dynamically resolves LazyVim's "default extras" (picker/cmp/explorer) based on `vim.g.lazyvim_*` globals and `lazyvim.json`'s saved state. Leaving it out would have silently dropped whatever it currently resolves to, so it's explicitly re-included.

## Verified

Rather than hand-tracing `xtras.lua`'s resolution logic (it's involved enough that my own manual trace turned out to be wrong in one place -- I initially expected `neo-tree.nvim` to be pulled in this way, and it isn't), verified empirically:
- Built `packages.bundle` before and after this change, ran `Lazy! sync` in isolated environments for each, and diffed the resulting `lazy-lock.json` files.
- **Byte-for-byte identical**: same 41 plugins, same pinned commits, nothing added or removed.
- Smoke test, `nix flake check --all-systems`, and the full lint suite all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)