### PR TITLE
fix(nix): stop calling deprecated neovimUtils.makeNeovimConfig

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,11 +29,36 @@
             '';
           };
 
-          kapiVimConfig = pkgs.neovimUtils.makeNeovimConfig {
+          # neovimUtils.makeNeovimConfig is deprecated as of nixpkgs 26.05
+          # ("use wrapNeovim or wrapNeovimUnstable directly"), so pass
+          # viAlias/vimAlias/wrapRc/plugins straight to wrapNeovimUnstable
+          # below instead of through it -- it accepts them directly.
+          #
+          # makeNeovimConfig also unconditionally added LUA_PATH/LUA_CPATH
+          # wrapperArgs pointing at neovim-unwrapped's own lua env; confirmed
+          # (by diffing the built wrapper script before/after this change)
+          # that wrapNeovimUnstable does NOT reproduce this itself when
+          # wrapRc = false (its own equivalent mechanism is embedded in the
+          # auto-generated init.lua, which wrapRc = false skips in favor of
+          # bundleConf's own -u flag) -- so replicate that computation
+          # explicitly here rather than silently lose it.
+          kapiVimConfig = {
             viAlias = true;
             vimAlias = true;
             wrapRc = false;
             plugins = [ ];
+            wrapperArgs =
+              let luaEnv = pkgs.neovim-unwrapped.lua.withPackages (_: [ ]);
+              in lib.optionals (luaEnv != null) [
+                "--prefix"
+                "LUA_PATH"
+                ";"
+                (pkgs.neovim-unwrapped.lua.pkgs.luaLib.genLuaPathAbsStr luaEnv)
+                "--prefix"
+                "LUA_CPATH"
+                ";"
+                (pkgs.neovim-unwrapped.lua.pkgs.luaLib.genLuaCPathAbsStr luaEnv)
+              ];
           };
 
           # Same config-wired-in flags packages.bundle uses, so packages.lite


### PR DESCRIPTION
## Summary

nixpkgs 26.05 deprecates `neovimUtils.makeNeovimConfig` ("use wrapNeovim or wrapNeovimUnstable directly", surfaced as a build warning during PR #32's verification). `wrapNeovimUnstable` accepts `viAlias`/`vimAlias`/`wrapRc`/`plugins` directly, so the intermediate call isn't needed for the shape of config kapi-vim passes.

That's *not* a drop-in no-op though: `makeNeovimConfig` unconditionally added `LUA_PATH`/`LUA_CPATH` `wrapperArgs` pointing at `neovim-unwrapped`'s own lua env. Diffing the actual built wrapper script before/after a naive removal showed `wrapNeovimUnstable` does **not** reproduce that when `wrapRc = false` (its own equivalent lives in the auto-generated `init.lua`, which `wrapRc = false` skips in favor of `bundleConf`'s own `-u` flag). Replicated that computation explicitly instead of silently dropping it.

## Verified

- `packages.default`'s derivation is now **byte-for-byte identical** to the original (same store hash), just without the deprecation warning -- not just "functionally equivalent," the literal same output.
- `bundle`/`lite` unaffected (their `wrapperArgs` were already fully overridden by `bundleConf`'s own `-u`/`--cmd` flags, before and after this change).
- Smoke test, `nix flake check --all-systems`, and the full lint suite all still pass.

(Noticed but out of scope for this PR: `nix flake check` now also warns that nixpkgs 26.05 is the last release supporting `x86_64-darwin` -- a separate, unrelated nixpkgs platform notice.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)