### PR TITLE
refactor(nvim): drop lazyvim.plugins.ui import

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -25,7 +25,6 @@
   "mini.pairs": { "branch": "main", "commit": "42407ccb80ec59c84e7c91d815f42ed90a8cc093" },
   "noice.nvim": { "branch": "main", "commit": "0427460c2d7f673ad60eb02b35f5e9926cf67c59" },
   "none-ls.nvim": { "branch": "main", "commit": "01f8e62ea11603e59ad9ff7afcfa94fd183f76d6" },
-  "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
   "nvim-autopairs": { "branch": "master", "commit": "7b9923abad60b903ece7c52940e1321d39eccc79" },
   "nvim-cmp": { "branch": "main", "commit": "a1d504892f2bc56c2e79b65c6faded2fd21f3eca" },
   "nvim-lint": { "branch": "master", "commit": "a219b2c9e5b4765e5c845aba119dad55806fcaf1" },

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -66,7 +66,6 @@ lazy.setup({
         -- ".init", not "lazyvim.plugins.lsp" -- that directory also has keymaps.lua, a non-spec helper module lazy.nvim would otherwise choke on.
         { import = "lazyvim.plugins.lsp.init" },
         { import = "lazyvim.plugins.treesitter" },
-        { import = "lazyvim.plugins.ui" },
         { import = "lazyvim.plugins.util" },
         { import = "lazyvim.plugins.xtras" },
         { import = "lazyvim.plugins.extras.editor.telescope" },

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -33,6 +33,13 @@ return {
             "nvim-treesitter/nvim-treesitter",
         },
     },
+    -- catppuccin's spec has an `optional = true` nested spec augmenting
+    -- bufferline.nvim, which errors (and collaterally drops unrelated
+    -- plugins from the lockfile write, e.g. codecompanion.nvim -- confirmed
+    -- empirically) if bufferline.nvim has no spec entry anywhere at all.
+    -- Registering it disabled, like the others below, keeps that hook happy
+    -- without actually loading bufferline.
+    { "akinsho/bufferline.nvim", enabled = false },
     { "folke/noice.nvim", enabled = false },
     { "mason-org/mason-lspconfig.nvim", enabled = false },
     { "mason-org/mason.nvim", enabled = false },


### PR DESCRIPTION
## Summary

Part of gradually dropping the LazyVim framework dependency, one plugin category at a time, so each removal can actually be lived with for a few days before deciding it's worth it — rather than guessing upfront which of LazyVim's defaults you actually use. This one drops the `ui` category (`{ import = "lazyvim.plugins.ui" }`). Most of `ui`'s plugins (`noice.nvim`, `mini.icons`, `lualine.nvim`) were already hand-disabled before this PR; the two live ones it actually provided were `bufferline.nvim` and `nui.nvim`.

**Why `nui.nvim` specifically:** it's a UI-component library (popups, menus, inputs) with no keymaps or features of its own — other plugins pull it in as a dependency to render *their* UI. Checked every plugin spec actually in this config's active import list (every LazyVim module we import, plus this repo's own `lua/plugins/*.lua`): the only place `nui.nvim` is declared at all is `ui.lua`'s own `{ "MunifTanjim/nui.nvim", lazy = true }` line, and its only real consumer among what we use is `noice.nvim` — which was already disabled before this PR. Nothing else references it, so it was dead weight: an extra clone, an extra lockfile entry, for a library nothing was calling into. Dropping the import removes it with no functional loss.

**`bufferline.nvim` is kept as a disabled stub, not fully removed:** `catppuccin`'s spec has a hook that only fires if `bufferline.nvim` has a spec entry *somewhere*, even a disabled one. Removing it outright broke that hook and silently corrupted lockfile entries for unrelated plugins (confirmed empirically — `codecompanion.nvim` lost its pin).

Also drops `snacks.nvim`'s indent/input/notifier/scroll/toggle/words/dashboard opts, which lived in this same LazyVim module. Unlike `nui.nvim`, these weren't verified as unused before merging — worth watching for whether any of that turns out to be missed in daily use.

## Test plan

- [x] `nix flake check --all-systems`, full lint suite
- [x] `packages.lite`: `:Lazy restore` in an isolated env, diffed against committed `lazy-lock.json` — exact match
- [x] Smoke test passes
- [ ] A few days of real daily-driver usage — merged without this; watch for anything from `ui` (bufferline tabs, noice's UI, snacks' notifications/dashboard) turning out to be missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)