### PR TITLE
fix(nvim): lazy.nvim import-order warning and treesitter master-branch crash

### DIFF
--- a/.github/scripts/smoke-test.lua
+++ b/.github/scripts/smoke-test.lua
@@ -63,24 +63,15 @@ if #spec_errors > 0 then
   vim.cmd("cquit 1")
 end
 
--- LazyVim ships its own import-order check (fired on the VeryLazy autocmd,
--- via vim.g.lazyvim_check_order), but it only recognizes a spec module
--- literally named "lazyvim.plugins" as import #1 -- this repo replaces that
--- blanket import with per-category ones (lua/config/lazy.lua), so that
--- check always false-positives here and is disabled. It's also a plain
--- vim.notify call gated behind VeryLazy, which never fires in --headless
--- (no UI ever attaches to trigger it), so CI could never have seen it fire
--- either way. Verify the actual invariant it exists to enforce -- core
--- lazyvim.plugins.* imports before lazyvim.plugins.extras.* before our own
--- `plugins` -- directly against the resolved import list instead.
+-- LazyVim's own import-order check is disabled (lua/config/lazy.lua) and,
+-- being a plain vim.notify on VeryLazy, could never fire under --headless
+-- anyway. Check the same invariant directly instead: core lazyvim.plugins.*
+-- imports before lazyvim.plugins.extras.* before our own `plugins`.
 local order_errors = {}
 do
-  -- min/max per category, not first/last-seen -- a single misplaced import
-  -- (e.g. landing in the middle of the extras list instead of before or
-  -- after all of them) has to move a min or a max to be visible; tracking
-  -- only "first extra" / "last core" missed exactly that case, confirmed
-  -- empirically by moving `plugins` between two extras imports and seeing
-  -- the then-current version of this check pass anyway.
+  -- Track min/max per category rather than first/last-seen, so a single
+  -- import landing mid-list (not just at the very front/back) still trips
+  -- this check.
   local core, extra, own = {}, {}, {}
   for i, m in ipairs(require("lazy.core.config").spec.modules) do
     if m:match("^lazyvim%.plugins%.extras%.") then

--- a/.github/scripts/smoke-test.lua
+++ b/.github/scripts/smoke-test.lua
@@ -63,5 +63,49 @@ if #spec_errors > 0 then
   vim.cmd("cquit 1")
 end
 
+-- LazyVim ships its own import-order check (fired on the VeryLazy autocmd,
+-- via vim.g.lazyvim_check_order), but it only recognizes a spec module
+-- literally named "lazyvim.plugins" as import #1 -- this repo replaces that
+-- blanket import with per-category ones (lua/config/lazy.lua), so that
+-- check always false-positives here and is disabled. It's also a plain
+-- vim.notify call gated behind VeryLazy, which never fires in --headless
+-- (no UI ever attaches to trigger it), so CI could never have seen it fire
+-- either way. Verify the actual invariant it exists to enforce -- core
+-- lazyvim.plugins.* imports before lazyvim.plugins.extras.* before our own
+-- `plugins` -- directly against the resolved import list instead.
+local order_errors = {}
+do
+  -- min/max per category, not first/last-seen -- a single misplaced import
+  -- (e.g. landing in the middle of the extras list instead of before or
+  -- after all of them) has to move a min or a max to be visible; tracking
+  -- only "first extra" / "last core" missed exactly that case, confirmed
+  -- empirically by moving `plugins` between two extras imports and seeing
+  -- the then-current version of this check pass anyway.
+  local core, extra, own = {}, {}, {}
+  for i, m in ipairs(require("lazy.core.config").spec.modules) do
+    if m:match("^lazyvim%.plugins%.extras%.") then
+      extra.min, extra.max = math.min(extra.min or i, i), math.max(extra.max or i, i)
+    elseif m == "plugins" then
+      own.min, own.max = math.min(own.min or i, i), math.max(own.max or i, i)
+    elseif m:match("^lazyvim%.plugins") then
+      core.min, core.max = math.min(core.min or i, i), math.max(core.max or i, i)
+    end
+  end
+  if core.max and extra.min and core.max > extra.min then
+    table.insert(order_errors, "a lazyvim.plugins.extras.* import appears before a core lazyvim.plugins.* import")
+  end
+  if core.max and own.min and core.max > own.min then
+    table.insert(order_errors, "the `plugins` import appears before a core lazyvim.plugins.* import")
+  end
+  if extra.max and own.min and extra.max > own.min then
+    table.insert(order_errors, "the `plugins` import appears before a lazyvim.plugins.extras.* import")
+  end
+end
+
+if #order_errors > 0 then
+  io.stderr:write("kapi-vim smoke test FAILED -- lazy.nvim import order is wrong:\n" .. table.concat(order_errors, "\n") .. "\n")
+  vim.cmd("cquit 1")
+end
+
 print("kapi-vim smoke test passed: startup clean, expected LSP binaries present (" .. table.concat(required_binaries, ", ") .. ")")
 vim.cmd("qa!")

--- a/.github/scripts/smoke-test.lua
+++ b/.github/scripts/smoke-test.lua
@@ -82,14 +82,20 @@ do
       core.min, core.max = math.min(core.min or i, i), math.max(core.max or i, i)
     end
   end
-  if core.max and extra.min and core.max > extra.min then
-    table.insert(order_errors, "a lazyvim.plugins.extras.* import appears before a core lazyvim.plugins.* import")
-  end
-  if core.max and own.min and core.max > own.min then
-    table.insert(order_errors, "the `plugins` import appears before a core lazyvim.plugins.* import")
-  end
-  if extra.max and own.min and extra.max > own.min then
-    table.insert(order_errors, "the `plugins` import appears before a lazyvim.plugins.extras.* import")
+  -- {should-come-first, should-come-after, names} -- if `first`'s last
+  -- import lands past `after`'s first, something from `after` snuck in
+  -- too early.
+  local core_name, extra_name, own_name = "a core lazyvim.plugins.* import", "a lazyvim.plugins.extras.* import", "the `plugins` import"
+  local expected_order = {
+    { core, extra, core_name, extra_name },
+    { core, own, core_name, own_name },
+    { extra, own, extra_name, own_name },
+  }
+  for _, check in ipairs(expected_order) do
+    local first, after, first_name, after_name = check[1], check[2], check[3], check[4]
+    if first.max and after.min and first.max > after.min then
+      table.insert(order_errors, after_name .. " appears before " .. first_name)
+    end
   end
 end
 

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -31,7 +31,7 @@
   "nvim-lint": { "branch": "master", "commit": "a219b2c9e5b4765e5c845aba119dad55806fcaf1" },
   "nvim-lspconfig": { "branch": "master", "commit": "d224a1920728ba129880efc700d4a0180ac4ecbb" },
   "nvim-snippets": { "branch": "main", "commit": "56b4052f71220144689caaa2e5b66222ba5661eb" },
-  "nvim-treesitter": { "branch": "master", "commit": "cf12346a3414fa1b06af75c79faebe7f76df080a" },
+  "nvim-treesitter": { "branch": "main", "commit": "4916d6592ede8c07973490d9322f187e07dfefac" },
   "nvim-treesitter-textobjects": { "branch": "main", "commit": "851e865342e5a4cb1ae23d31caf6e991e1c99f1e" },
   "nvim-ts-autotag": { "branch": "main", "commit": "88c1453db4ba7dd24131086fe51fdf74e587d275" },
   "nvim-web-devicons": { "branch": "master", "commit": "dad71387de386a946b123079d0e53f23028f3abd" },

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -40,6 +40,17 @@ if vim.fn.filewritable(config_root) ~= 2 then
     end
 end
 
+-- LazyVim's own import-order check (fired on the VeryLazy autocmd) only
+-- looks for a spec module literally named "lazyvim.plugins" as import #1
+-- (lazyvim/config/init.lua: `find("^lazyvim%.plugins$")`). This repo never
+-- imports that literal module -- the per-category imports below replace it
+-- on purpose (see the comment above) -- so `lazyvim_plugins` is always nil
+-- and the check fires unconditionally, regardless of actual order. Our
+-- order (LazyVim core categories, then xtras/extras, then our own
+-- `plugins`) is exactly what the check wants; it just can't see it under
+-- this structure. Disabled via LazyVim's own documented escape hatch.
+vim.g.lazyvim_check_order = false
+
 lazy.setup({
     lockfile = lockfile,
     spec = {

--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -40,15 +40,10 @@ if vim.fn.filewritable(config_root) ~= 2 then
     end
 end
 
--- LazyVim's own import-order check (fired on the VeryLazy autocmd) only
--- looks for a spec module literally named "lazyvim.plugins" as import #1
--- (lazyvim/config/init.lua: `find("^lazyvim%.plugins$")`). This repo never
--- imports that literal module -- the per-category imports below replace it
--- on purpose (see the comment above) -- so `lazyvim_plugins` is always nil
--- and the check fires unconditionally, regardless of actual order. Our
--- order (LazyVim core categories, then xtras/extras, then our own
--- `plugins`) is exactly what the check wants; it just can't see it under
--- this structure. Disabled via LazyVim's own documented escape hatch.
+-- LazyVim's import-order check only recognizes a spec module literally
+-- named "lazyvim.plugins" as import #1. We never import that (see the
+-- per-category imports below), so it always false-positives regardless of
+-- actual order. Disabled via LazyVim's own documented escape hatch.
 vim.g.lazyvim_check_order = false
 
 lazy.setup({

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -1,65 +1,32 @@
 return {
-    "nvim-treesitter/nvim-treesitter",
-    branch = "master",
-    opts = {
-        ensure_installed = {
-            "asm",
-            "bash",
-            "c",
-            "cmake",
-            "comment",
-            "dockerfile",
-            "git_config",
-            "git_rebase",
-            "gitcommit",
-            "gitignore",
-            "go",
-            "gomod",
-            "gosum",
-            "haskell",
-            "html",
-            "javascript",
-            "jq",
-            "json",
-            "lua",
-            "luadoc",
-            "nix",
-            "objdump",
-            "ocaml",
-            "python",
-            "rust",
-            "sql",
-            "toml",
-            "typst",
-            "vim",
-            "vimdoc",
-            "yaml",
-        },
-        sync_install = false,
-        auto_install = true,
-        autopairs = {
-            enable = true,
-        },
-        highlight = {
-            enable = true,
-            additional_vim_regex_highlighting = false,
-        },
-        indent = { enable = true, disable = { "yaml" } },
-    },
-    config = function(_, opts)
-        local config = require("nvim-treesitter.parsers").get_parser_configs()
-        config.jasmin = {
-            install_info = {
-                url = "https://github.com/y4cer/tree-sitter-jasmin",
-                files = { "src/parser.c" },
-                generate_requires_npm = false,
-                requires_generate_from_grammar = false,
+    {
+        "nvim-treesitter/nvim-treesitter",
+        opts = {
+            -- Languages this repo needs beyond LazyVim's own defaults
+            -- (lazyvim.plugins.treesitter, opts_extend'd rather than
+            -- replaced -- see lua/config/lazy.lua for import order).
+            ensure_installed = {
+                "asm",
+                "cmake",
+                "comment",
+                "dockerfile",
+                "git_config",
+                "git_rebase",
+                "gitcommit",
+                "gitignore",
+                "go",
+                "gomod",
+                "gosum",
+                "haskell",
+                "jq",
+                "nix",
+                "objdump",
+                "ocaml",
+                "rust",
+                "sql",
+                "typst",
             },
-        }
-        if type(opts.ensure_installed) == "table" then
-            opts.ensure_installed = LazyVim.dedup(opts.ensure_installed)
-        end
-
-        require("nvim-treesitter.configs").setup(opts)
-    end,
+            indent = { enable = true, disable = { "yaml" } },
+        },
+    },
 }


### PR DESCRIPTION
## Summary

Two startup/runtime bugs, both false alarms from our end but real enough to fix.

**Import-order warning on every startup.** LazyVim's own sanity check for import order doesn't understand how this repo structures its imports, so it always complains even though the order is correct. Turned it off using LazyVim's supported setting, and added a real check to CI that verifies the actual order instead.

**Crash on hover (`K`) over markdown code blocks.** Caused by `nvim-treesitter`'s old `master` branch, which is now archived upstream and broken on Neovim 0.12. LazyVim itself already moved on to the newer `main` branch; this repo had its own override pinning back to the old one (originally for a custom grammar we no longer need). Removed the override so LazyVim's modern config takes over.

## Test plan

- [x] Reproduced both issues, confirmed both fixes resolve them
- [x] New CI check verified both ways: fails on a broken import order, passes on the correct one
- [x] Fresh plugin install from the updated lockfile works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)